### PR TITLE
Revise download/extraction step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ python download_snapchat_memories_gui.py
 
 7. **Wait 24-48 hours** for Snapchat to prepare your data
 8. **Download the ZIP** when you receive the email from Snapchat
-9. **Extract the ZIP** (right-click → "Extract All..." on Windows):
+
+> **Note:** If you have multiple zip files available for download, only the first (non-numbered) folder contains the `memories_history.json` file.
+> 
+10. **Extract the ZIP** (right-click → "Extract All..." on Windows):
 
    ![Unzipped Folder](images/Unzipped_folder.png)
 
-10. Locate `memories_history.json` in the extracted folder (usually in the root or `json` subfolder)
+11. Locate `memories_history.json` in the extracted folder (usually in the root or `json` subfolder)
 
 ## 📖 How to Use
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ python download_snapchat_memories_gui.py
 7. **Wait 24-48 hours** for Snapchat to prepare your data
 8. **Download the ZIP** when you receive the email from Snapchat
 
-> **Note:** If you have multiple zip files available for download, only the first (non-numbered) folder contains the `memories_history.json` file.
+> **Note:** If you have multiple zip files available for download, only the first (non-numbered) folder contains the `memories_history.json` file. The JSON contains all memories from the request, regardless of only being located in the first folder.
 > 
-10. **Extract the ZIP** (right-click → "Extract All..." on Windows):
+9. **Extract the ZIP** (right-click → "Extract All..." on Windows):
 
    ![Unzipped Folder](images/Unzipped_folder.png)
 
-11. Locate `memories_history.json` in the extracted folder (usually in the root or `json` subfolder)
+10. Locate `memories_history.json` in the extracted folder (usually in the root or `json` subfolder)
 
 ## 📖 How to Use
 


### PR DESCRIPTION
When using this tool, I initially downloaded all the zip files before realizing the memories_history.json file is only in the first archive.

Updated instructions in README to help anyone else using this tool. 

Example of multiple downloads available:
<img width="538" height="404" alt="Screenshot_1" src="https://github.com/user-attachments/assets/a56ddaeb-01ec-4512-b07d-d20a9cabb3a6" />
